### PR TITLE
Support multi-line directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ load-plugins = [
 ```
 
 ## Usage
-Add a list of patterns and codes you would like to ignore.
-The patterns are matched using [globs](https://docs.python.org/3/library/glob.html).
-The config is parsed based on newlines, meaning each line should follow the pattern `<file-pattern>:<rule1>,<rule2>`.
-Newlines between rules are not supported.
+Add a list of directives. Each directive contains a [glob](https://docs.python.org/3/library/glob.html) pattern followed by a colon followed by a comma-separated list of Pylint codes to ignore in the matched files. A list of Pylint codes may contain whitespace and/or a trailing comma.
 
 > Prior to v2.0.0, `pylint-per-file-ignores` did not use globs but regex.
 > When migrating, please check your configuration carefully.
@@ -67,16 +64,6 @@ per-file-ignores = [
     "/folder_1/*:missing-function-docstring,W0621,W0240,C0115",
     "file.py:C0116,E0001"
 ]
-```
-
-Please note, that for non-toml files newlines are important.
-For example, the following won't parse as expected
-
-```ini
-[pylint.MESSAGES CONTROL]
-per-file-ignores =
-  /folder_1/*:missing-function-docstring,
-    missing-class-docstring
 ```
 
 ## Development

--- a/pylint_per_file_ignores/_plugin.py
+++ b/pylint_per_file_ignores/_plugin.py
@@ -73,25 +73,23 @@ def register(linter: PyLinter) -> None:
 
 
 def _parse_string(input_string: str) -> list[str]:
-    if "\n" in input_string:
-        result = []
-        for line in input_string.split("\n"):
-            if line.strip():
-                result.extend(_parse_string(line))
-        return result
-
+    input_string = input_string.replace("\n", ",")
     parts = input_string.split(",")
 
     result = []
     current_file = None
     current_errors = []
     for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
         if ":" in part:
             if current_file is not None:
                 result.append(f"{current_file}:{','.join(current_errors)}")
 
             current_file, error = part.split(":", 1)
-            current_errors = [error]
+            current_errors = [error.strip()]
         else:
             current_errors.append(part)
 

--- a/test/test_config_parsing.py
+++ b/test/test_config_parsing.py
@@ -63,26 +63,22 @@ def test_without_per_file_ignores(runner: Runner) -> None:
     assert _get_symbols(result, "b") == ["invalid-name", "missing-module-docstring"]
 
 
-def test_config_pyproject_toml(runner: Runner) -> None:
-    """Test per-file-ignores config parsed from pyproject.toml."""
-    result = runner("test_config_pyproject_toml")
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ConfigTestCase:
 
-    assert _get_symbols(result, "a") == ["invalid-name"]
-    assert _get_symbols(result, "b") == ["missing-module-docstring"]
-
-
-@dataclasses.dataclass
-class PylintrcTestCase:
-
-    @dataclasses.dataclass
+    @dataclasses.dataclass(frozen=True, kw_only=True)
     class Descriptor:
         """Describes the configuration style covered by the test case.
 
         Attributes:
-            multiple_directives: Whether there are multiple directives (`True`) or just one (`False`).
-            multiple_message_ids: Whether there are multiple message IDs within a given directive (`True`) or just one (`False`).
-            multiline_message_ids: Whether message IDs within a given directive are separated by a comma and a newline (`True`) or just a comma (`False`).
-            comma_after_each_directive: Whether there is a trailing comma after the last message ID in each directive.
+            multiple_directives: Whether there are multiple directives (`True`) or just one
+                (`False`).
+            multiple_message_ids: Whether there are multiple message IDs within a given directive
+                (`True`) or just one (`False`).
+            multiline_message_ids: Whether message IDs within a given directive are separated by a
+                comma and a newline (`True`) or just a comma (`False`).
+            comma_after_each_directive: Whether there is a trailing comma after the last message ID
+                in each directive.
         """
 
         multiple_directives: bool
@@ -91,7 +87,8 @@ class PylintrcTestCase:
         comma_after_each_directive: bool
 
     descriptor: Descriptor
-    messages_control_content: str
+    ini_content: str
+    toml_content: str
     a_expected: list[str]
     b_expected: list[str]
 
@@ -123,239 +120,331 @@ class PylintrcTestCase:
         return "__".join(id_parts)
 
 
-PYLINTRC_CASES = [
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+CONFIG_CASES = [
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=True,
             multiple_message_ids=True,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                      unused-import,
                 b.py:C0103,
             """),
+        toml_content=textwrap.dedent('''\
+            per-file-ignores = [
+                """a.py:missing-module-docstring,
+                        unused-import,""",
+                "b.py:C0103,",
+            ]
+            '''),
         a_expected=["invalid-name"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=True,
             multiple_message_ids=True,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                      unused-import,
             """),
+        toml_content=textwrap.dedent('''\
+            per-file-ignores = [
+                """a.py:missing-module-docstring,
+                        unused-import,""",
+            ]
+            '''),
         a_expected=["invalid-name"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=True,
             multiple_message_ids=False,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                 b.py:C0103,
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,",
+                "b.py:C0103,",
+            ]
+            """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=True,
             multiple_message_ids=False,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,",
+            ]
             """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=False,
             multiple_message_ids=True,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,unused-import,
                 b.py:C0103,
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,unused-import,",
+                "b.py:C0103,",
+            ]
+            """),
         a_expected=["invalid-name"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=False,
             multiple_message_ids=True,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,unused-import,
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,unused-import,",
+            ]
             """),
         a_expected=["invalid-name"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=False,
             multiple_message_ids=False,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                 b.py:C0103,
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,",
+                "b.py:C0103,",
+            ]
+            """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=True,
             multiline_message_ids=False,
             multiple_message_ids=False,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,",
+            ]
             """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=True,
             multiple_message_ids=True,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                      unused-import
                 b.py:C0103
             """),
+        toml_content=textwrap.dedent('''\
+            per-file-ignores = [
+                """a.py:missing-module-docstring,
+                        unused-import""",
+                "b.py:C0103"
+            ]
+            '''),
         a_expected=["invalid-name"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=True,
             multiple_message_ids=True,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,
                      unused-import
             """),
+        toml_content=textwrap.dedent('''\
+            per-file-ignores = [
+                """a.py:missing-module-docstring,
+                        unused-import"""
+            ]
+            '''),
         a_expected=["invalid-name"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=True,
             multiple_message_ids=False,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring
                 b.py:C0103
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring",
+                "b.py:C0103"
+            ]
+            """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=True,
             multiple_message_ids=False,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring"
+            ]
             """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=False,
             multiple_message_ids=True,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,unused-import
                 b.py:C0103
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,unused-import",
+                "b.py:C0103"
+            ]
+            """),
         a_expected=["invalid-name"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=False,
             multiple_message_ids=True,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring,unused-import
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring,unused-import"
+            ]
             """),
         a_expected=["invalid-name"],
         b_expected=["invalid-name", "missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=False,
             multiple_message_ids=False,
             multiple_directives=True,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring
                 b.py:C0103
             """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring",
+                "b.py:C0103"
+            ]
+            """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["missing-module-docstring"],
     ),
-    PylintrcTestCase(
-        descriptor=PylintrcTestCase.Descriptor(
+    ConfigTestCase(
+        descriptor=ConfigTestCase.Descriptor(
             comma_after_each_directive=False,
             multiline_message_ids=False,
             multiple_message_ids=False,
             multiple_directives=False,
         ),
-        messages_control_content=textwrap.dedent("""\
+        ini_content=textwrap.dedent("""\
             per-file-ignores =
                 a.py:missing-module-docstring
+            """),
+        toml_content=textwrap.dedent("""\
+            per-file-ignores = [
+                "a.py:missing-module-docstring"
+            ]
             """),
         a_expected=["invalid-name", "unused-import"],
         b_expected=["invalid-name", "missing-module-docstring"],
@@ -363,8 +452,8 @@ PYLINTRC_CASES = [
 ]
 
 
-@pytest.mark.parametrize("case", PYLINTRC_CASES, ids=lambda c: c.id)
-def test_config_pylintrc(runner: Runner, case: PylintrcTestCase) -> None:
+@pytest.mark.parametrize("case", CONFIG_CASES, ids=lambda c: c.id)
+def test_config_pylintrc(runner: Runner, case: ConfigTestCase) -> None:
     """Test per-file-ignores config parsed from .pylintrc."""
     cwd = runner.datadir / "test_config_pylintrc"
     pylintrc = cwd / ".pylintrc"
@@ -375,7 +464,7 @@ def test_config_pylintrc(runner: Runner, case: PylintrcTestCase) -> None:
         load-plugins = pylint_per_file_ignores
 
         [MESSAGES CONTROL]
-        """) + case.messages_control_content
+        """) + case.ini_content
 
     try:
         pylintrc.write_text(content)
@@ -387,9 +476,49 @@ def test_config_pylintrc(runner: Runner, case: PylintrcTestCase) -> None:
         pylintrc.write_text(original_content)
 
 
-def test_config_setup_cfg(runner: Runner) -> None:
+@pytest.mark.parametrize("case", CONFIG_CASES, ids=lambda c: c.id)
+def test_config_setup_cfg(runner: Runner, case: ConfigTestCase) -> None:
     """Test per-file-ignores config parsed from setup.cfg."""
-    result = runner("test_config_setup_cfg")
+    cwd = runner.datadir / "test_config_setup_cfg"
+    setup_cfg = cwd / "setup.cfg"
+    original_content = setup_cfg.read_text()
 
-    assert _get_symbols(result, "a") == ["invalid-name"]
-    assert _get_symbols(result, "b") == ["missing-module-docstring"]
+    content = textwrap.dedent("""\
+        [pylint.main]
+        load-plugins = pylint_per_file_ignores
+
+        [pylint.messages control]
+        """) + case.ini_content
+
+    try:
+        setup_cfg.write_text(content)
+        result = runner("test_config_setup_cfg")
+
+        assert _get_symbols(result, "a") == case.a_expected
+        assert _get_symbols(result, "b") == case.b_expected
+    finally:
+        setup_cfg.write_text(original_content)
+
+
+@pytest.mark.parametrize("case", CONFIG_CASES, ids=lambda c: c.id)
+def test_config_pyproject_toml(runner: Runner, case: ConfigTestCase) -> None:
+    """Test per-file-ignores config parsed from pyproject.toml."""
+    cwd = runner.datadir / "test_config_pyproject_toml"
+    pyproject_toml = cwd / "pyproject.toml"
+    original_content = pyproject_toml.read_text()
+
+    content = textwrap.dedent("""\
+        [tool.pylint.main]
+        load-plugins = ["pylint_per_file_ignores"]
+
+        [tool.pylint.'messages control']
+        """) + case.toml_content
+
+    try:
+        pyproject_toml.write_text(content)
+        result = runner("test_config_pyproject_toml")
+
+        assert _get_symbols(result, "a") == case.a_expected
+        assert _get_symbols(result, "b") == case.b_expected
+    finally:
+        pyproject_toml.write_text(original_content)

--- a/test/test_config_parsing.py
+++ b/test/test_config_parsing.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import re
 import shutil
 import subprocess
+import textwrap
 from pathlib import Path
 from typing import Any, cast
 
@@ -69,20 +71,320 @@ def test_config_pyproject_toml(runner: Runner) -> None:
     assert _get_symbols(result, "b") == ["missing-module-docstring"]
 
 
-@pytest.mark.parametrize("trailing_comma", [True, False])
-def test_config_pylintrc(runner: Runner, *, trailing_comma: bool) -> None:
+@dataclasses.dataclass
+class PylintrcTestCase:
+
+    @dataclasses.dataclass
+    class Descriptor:
+        """Describes the configuration style covered by the test case.
+
+        Attributes:
+            multiple_directives: Whether there are multiple directives (`True`) or just one (`False`).
+            multiple_message_ids: Whether there are multiple message IDs within a given directive (`True`) or just one (`False`).
+            multiline_message_ids: Whether message IDs within a given directive are separated by a comma and a newline (`True`) or just a comma (`False`).
+            comma_after_each_directive: Whether there is a trailing comma after the last message ID in each directive.
+        """
+
+        multiple_directives: bool
+        multiple_message_ids: bool
+        multiline_message_ids: bool
+        comma_after_each_directive: bool
+
+    descriptor: Descriptor
+    messages_control_content: str
+    a_expected: list[str]
+    b_expected: list[str]
+
+    @property
+    def id(self):
+        descriptor = self.descriptor
+        id_parts = [
+            (
+                "multiple_directives"
+                if descriptor.multiple_directives
+                else "single_directive"
+            ),
+            (
+                "multiple_message_ids"
+                if descriptor.multiple_message_ids
+                else "single_message_ids"
+            ),
+            (
+                "multiple_lines_message_ids"
+                if descriptor.multiline_message_ids
+                else "single_line_message_ids"
+            ),
+            (
+                "comma_after_each_directive"
+                if descriptor.comma_after_each_directive
+                else "no_comma_after_each_directive"
+            ),
+        ]
+        return "__".join(id_parts)
+
+
+PYLINTRC_CASES = [
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=True,
+            multiple_message_ids=True,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                     unused-import,
+                b.py:C0103,
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=True,
+            multiple_message_ids=True,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                     unused-import,
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=True,
+            multiple_message_ids=False,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                b.py:C0103,
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=True,
+            multiple_message_ids=False,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=False,
+            multiple_message_ids=True,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,unused-import,
+                b.py:C0103,
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=False,
+            multiple_message_ids=True,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,unused-import,
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=False,
+            multiple_message_ids=False,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                b.py:C0103,
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=True,
+            multiline_message_ids=False,
+            multiple_message_ids=False,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=True,
+            multiple_message_ids=True,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                     unused-import
+                b.py:C0103
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=True,
+            multiple_message_ids=True,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,
+                     unused-import
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=True,
+            multiple_message_ids=False,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring
+                b.py:C0103
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=True,
+            multiple_message_ids=False,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=False,
+            multiple_message_ids=True,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,unused-import
+                b.py:C0103
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=False,
+            multiple_message_ids=True,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring,unused-import
+            """),
+        a_expected=["invalid-name"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=False,
+            multiple_message_ids=False,
+            multiple_directives=True,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring
+                b.py:C0103
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["missing-module-docstring"],
+    ),
+    PylintrcTestCase(
+        descriptor=PylintrcTestCase.Descriptor(
+            comma_after_each_directive=False,
+            multiline_message_ids=False,
+            multiple_message_ids=False,
+            multiple_directives=False,
+        ),
+        messages_control_content=textwrap.dedent("""\
+            per-file-ignores =
+                a.py:missing-module-docstring
+            """),
+        a_expected=["invalid-name", "unused-import"],
+        b_expected=["invalid-name", "missing-module-docstring"],
+    ),
+]
+
+
+@pytest.mark.parametrize("case", PYLINTRC_CASES, ids=lambda c: c.id)
+def test_config_pylintrc(runner: Runner, case: PylintrcTestCase) -> None:
     """Test per-file-ignores config parsed from .pylintrc."""
     cwd = runner.datadir / "test_config_pylintrc"
-    if trailing_comma:
-        pylintrc = cwd / ".pylintrc"
-        content = pylintrc.read_text()
-        content = A_PY_PATTERN.sub(r"a.py:\1,", content)
+    pylintrc = cwd / ".pylintrc"
+    original_content = pylintrc.read_text()
+
+    content = textwrap.dedent("""\
+        [MAIN]
+        load-plugins = pylint_per_file_ignores
+
+        [MESSAGES CONTROL]
+        """) + case.messages_control_content
+
+    try:
         pylintrc.write_text(content)
+        result = runner("test_config_pylintrc")
 
-    result = runner("test_config_pylintrc")
-
-    assert _get_symbols(result, "a") == ["invalid-name"]
-    assert _get_symbols(result, "b") == ["missing-module-docstring"]
+        assert _get_symbols(result, "a") == case.a_expected
+        assert _get_symbols(result, "b") == case.b_expected
+    finally:
+        pylintrc.write_text(original_content)
 
 
 def test_config_setup_cfg(runner: Runner) -> None:


### PR DESCRIPTION
* Updates `_plugin.py` to support trailing commas in directives.
* Adds tests to exercise more formatting styles.
  * The `ConfigTestCase` dataclass encapsulates a single test case that generalizes to both INI and TOML formats.
  * The `ConfigTestCase.Descriptor` dataclass encodes the formatting style under test.

Closes #163.