### PR TITLE
Update development setup Section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,17 @@ per-file-ignores =
 ```
 
 ## Development
-This project uses [`uv`](https://docs.astral.sh/uv/), which must be installed beforehand.
+This project uses [`uv`](https://docs.astral.sh/uv/).
 To install uv, and setup a venv for development, use:
 ```
-pip install uv
-uv sync --all-groups
-
+python3.14 -m venv venv && \
+    source venv/bin/activate && \
+    pip install uv && uv sync --all-groups && \
+    deactivate  && \
+    rm -rf venv/
 ```
+This will create a temporary `venv`, install uv to bootstrap the project
+`.venv`, and remove the temporary `venv` again.
 Then use `source .venv/bin/activate` to activate your venv.
 
 ## Build and Publish

--- a/README.md
+++ b/README.md
@@ -81,7 +81,12 @@ per-file-ignores =
 
 ## Development
 This project uses [`uv`](https://docs.astral.sh/uv/), which must be installed beforehand.
-To setup a venv for development use `uv sync --all-groups`.
+To install uv, and setup a venv for development, use:
+```
+pip install uv
+uv sync --all-groups
+
+```
 Then use `source .venv/bin/activate` to activate your venv.
 
 ## Build and Publish

--- a/README.md
+++ b/README.md
@@ -80,9 +80,8 @@ per-file-ignores =
 ```
 
 ## Development
-This project uses `uv`.
-To setup a venv for development use
-`python3.14 -m venv venv && pip install uv && uv sync --all-groups && rm -rf venv/`.
+This project uses [`uv`](https://docs.astral.sh/uv/), which must be installed beforehand.
+To setup a venv for development use `uv sync --all-groups`.
 Then use `source .venv/bin/activate` to activate your venv.
 
 ## Build and Publish


### PR DESCRIPTION
Previous section created a venv, installed uv into the system venv, and then deleted the venv again. This was essentially a noop, while uv was installed into the currently active environment, likely the system env.